### PR TITLE
cargo: make the `locale` feature the default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,8 +147,8 @@ jobs:
     - name: Run tests
       run: ${{ env.CARGO }} test --verbose ${{ env.TARGET_FLAGS }}
 
-    - name: Run tests with locale support
-      run: ${{ env.CARGO }} test --verbose --features locale ${{ env.TARGET_FLAGS }}
+    - name: Run tests without locale support
+      run: ${{ env.CARGO }} test --verbose --no-default-features ${{ env.TARGET_FLAGS }}
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,7 +176,7 @@ jobs:
     - name: Build release binary
       shell: bash
       run: |
-        ${{ env.CARGO }} build --verbose --features locale --profile release-lto ${{ env.TARGET_FLAGS }}
+        ${{ env.CARGO }} build --verbose --profile release-lto ${{ env.TARGET_FLAGS }}
         if [ "${{ matrix.os }}" = "windows-latest" ]; then
           bin="target/${{ matrix.target }}/release-lto/bttf.exe"
         else

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ name = "bttf"
 path = "src/main.rs"
 
 [features]
+default = ["locale"]
 locale = [
   "dep:icu_calendar",
   "dep:icu_datetime",

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -1046,12 +1046,12 @@ bttf 0.1.0 (rev 2659045dba) (locale support enabled)
 ```
 
 If you don't see "locale support enabled" in the output, then that means your
-bttf installation cannot localize datetimes. To fix that, either rebuild bttf
-with the `locale` feature enabled, or use one of the binaries distributed on
-GitHub. If you installed bttf from a package manager, then you'll need to ask
-them to rebuild bttf with locale support enabled.
+bttf installation cannot localize datetimes. To fix that, rebuild bttf with
+default features enabled, or use one of the binaries distributed on GitHub. If
+you installed bttf from a package manager, then you'll need to ask them to
+rebuild bttf with locale support enabled.
 
-(Note that when bttf is compiled with the `locale` feature, all necessary
+(Note that locale support is enabled by default. When enabled, all necessary
 localization data is bundled into the binary. This increases the binary size
 of bttf substantially.)
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,8 @@ Sat, May 10, 2025, 8:02:04 AM EDT
 
 > [!TIP]
 > If you get output like `2025 M05 10, Mon 08:02:04` instead, that's because
-> you likely don't have [locale support][locale] support configured. That
-> requires setting `BTTF_LOCALE` and using a GitHub release binary or building
-> bttf with the `locale` feature enabled.
+> you likely don't have [locale support][locale] support configured. Enabling
+> locale support requires setting `BTTF_LOCALE` in your shell environment.
 
 Print the current time in a format of your choosing:
 
@@ -206,13 +205,15 @@ reduce the file size, run `strip` on the binary.
 cargo install bttf
 ```
 
-Or, if you want [locale support][locale] (which is enabled in the
-binaries distributed on GitHub), then install with the `locale` feature
-enabled:
+Or, if you want to disable [locale support][locale], install without default
+features:
 
 ```console
-cargo install bttf --features locale
+cargo install bttf --no-default-features
 ```
+
+The benefit of disabling locale support is faster compile times and a smaller
+`bttf` binary.
 
 ### bttf as a library
 
@@ -276,11 +277,11 @@ cargo build --release
 ./target/release/bttf --version
 ```
 
-Additionally, optional locale support can be built with bttf by enabling the
-`locale` feature:
+Locale support is enabled by default. To build without it, disable default
+features:
 
 ```console
-cargo build --release --features locale
+cargo build --release --no-default-features
 ```
 
 bttf can be built with the musl target on Linux by first installing the musl
@@ -293,7 +294,7 @@ rustup target add x86_64-unknown-linux-musl
 cargo build --release --target x86_64-unknown-linux-musl
 ```
 
-Applying the `--features locale` flag from above should also work.
+Applying the `--no-default-features` flag from above should also work.
 
 ### Running tests
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -58,7 +58,7 @@ fn bttf_bare() -> crate::command::Command {
     crate::command::bin("bttf")
         .env("TZ", "America/New_York")
         .env("BTTF_NOW", NOW.to_string())
-        // So that when tests are run with `--features locale`,
+        // So that when tests are run with locale support,
         // we still get consistent behavior as if bttf were
         // compiled without locale support.
         .env("BTTF_LOCALE", "und")


### PR DESCRIPTION
This should set the ground to avoid having the weird
`2026 M05 28, Thu 11:29:10 GMT-4` output when the locale isn't known.

This won't fix it entirely because the `BTTF_LOCALE` environment
variable still needs to be set. But once we have the ability to read and
convert a POSIX locale to a Unicode locale, then things should Just Work
in most cases with this being enabled by default.
