### PR TITLE
Fix version and help return status code

### DIFF
--- a/src/args/mod.rs
+++ b/src/args/mod.rs
@@ -85,6 +85,9 @@ pub fn configure(
                     usage.trim().to_string(),
                 )));
             }
+            Arg::Long("version") => {
+                return Err(anyhow::Error::from(Version));
+            }
             _ => {}
         }
         // We do this little dance to disentangle the lifetime of 'p' from the
@@ -184,7 +187,7 @@ pub fn next_as_command(usage: &str, p: &mut Parser) -> anyhow::Result<String> {
     let cmd = match arg {
         Arg::Value(cmd) => cmd.string()?,
         Arg::Short('h') | Arg::Long("help") => {
-            anyhow::bail!("{}", Help(usage.to_string()))
+            return Err(anyhow::Error::from(Help(usage.to_string())));
         }
         Arg::Long("version") => return Err(anyhow::Error::from(Version)),
         arg => return Err(arg.unexpected().into()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,10 @@ fn main() -> ExitCode {
         writeln!(&mut std::io::stdout(), "{help}").unwrap();
         return ExitCode::SUCCESS;
     }
+    if let Some(version) = err.root_cause().downcast_ref::<args::Version>() {
+        writeln!(&mut std::io::stdout(), "{version}").unwrap();
+        return ExitCode::SUCCESS;
+    }
     // Look for a broken pipe error. In this case, we generally want
     // to exit "gracefully" with a success exit code. This matches
     // existing Unix convention. We need to handle this explicitly

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -88,6 +88,141 @@ fn no_args() {
     );
 }
 
+/// Test that `--help` and `-h` print usage to stdout and exit successfully,
+/// both at the top level and on a command group.
+#[test]
+fn help() {
+    crate::command::assert_cmd_snapshot!(
+        bttf(["--help"]),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    A simple utility for doing datetime arithmetic, parsing and formatting.
+
+    USAGE:
+        bttf <command> ...
+
+    COMMANDS:
+        span   Tools for manipulating time spans/durations
+        time   Tools for manipulating datetimes
+        tag    Tag arbitrary data with datetimes or spans
+        tz     Commands for working directly with time zones
+        untag  Remove tags from previously tagged data
+
+    ----- stderr -----
+    ",
+    );
+    crate::command::assert_cmd_snapshot!(
+        bttf(["-h"]),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    A simple utility for doing datetime arithmetic, parsing and formatting.
+
+    USAGE:
+        bttf <command> ...
+
+    COMMANDS:
+        span   Tools for manipulating time spans/durations
+        time   Tools for manipulating datetimes
+        tag    Tag arbitrary data with datetimes or spans
+        tz     Commands for working directly with time zones
+        untag  Remove tags from previously tagged data
+
+    ----- stderr -----
+    ",
+    );
+    crate::command::assert_cmd_snapshot!(
+        bttf(["time", "--help"]),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Commands for working with datetimes.
+
+    USAGE:
+        bttf time <command> ...
+
+    COMMANDS:
+        add       Add a span to a datetime
+        cmp       Compare datetimes
+        end-of    Get the end of a year, month, week, etc
+        fmt       Format a datetime
+        in        Convert a datetime to a time zone
+        parse     Parse a datetime
+        relative  Parse a relative datetime
+        round     Round a datetime
+        seq       Generate a sequence of datetimes
+        sort      Sort datetimes
+        start-of  Get the start of a year, month, week, etc
+
+    ----- stderr -----
+    ",
+    );
+}
+
+/// Test that `--version` prints the version to stdout and exits successfully
+/// at the top level, on a command group, and on a leaf command. The version
+/// line embeds the crate version and git hash, so it is filtered to a stable
+/// placeholder.
+#[test]
+fn version() {
+    insta::with_settings!({
+        filters => vec![(r"bttf \d+\.\d+\.\d+.*", "bttf [VERSION]")],
+    }, {
+        crate::command::assert_cmd_snapshot!(
+            bttf(["--version"]),
+            @r"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+        bttf [VERSION]
+
+        ----- stderr -----
+        ",
+        );
+        crate::command::assert_cmd_snapshot!(
+            bttf(["time", "--version"]),
+            @r"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+        bttf [VERSION]
+
+        ----- stderr -----
+        ",
+        );
+        crate::command::assert_cmd_snapshot!(
+            bttf(["time", "fmt", "--version"]),
+            @r"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+        bttf [VERSION]
+
+        ----- stderr -----
+        ",
+        );
+        // We also test the case where `--version` is added after a command
+        // argument. This previously failed because we weren't checking for
+        // the `--version` flag in all cases (like we do for `--help`). I don't
+        // think this was intentional.
+        crate::command::assert_cmd_snapshot!(
+            bttf(["time", "fmt", "now", "--version"]),
+            @r"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+        bttf [VERSION]
+
+        ----- stderr -----
+        ",
+        );
+    });
+}
+
 /// Test that calling `bttf` when compiled with `locale` and when `BTTF_LOCALE`
 /// is set does something sensible.
 #[cfg(feature = "locale")]


### PR DESCRIPTION
`bttf --version` and `bttf --help` (from subcommands as well), were returning a status code of 1, which I thought was unexpected. This fixes both to return 0. 

Let me know if you want me to add any sort of formal testing around the changes.